### PR TITLE
Wip/b.hahn@phytec.de/isar renaming v1

### DIFF
--- a/kas_yogurt.yml
+++ b/kas_yogurt.yml
@@ -4,39 +4,39 @@ header:
 build_system: isar
 repos:
   isar:
-    url: "https://github.com/ilbers/isar"
+    url: "git@github.com:/ilbers/isar"
     refspec: "1fd9f5de842ba1ed4ccbb555527f25bc839a6a6b"
     layers:
       meta:
       meta-isar:
     patches:
       0001-separate-locks:
-        repo: meta-isar-qtdemo
+        repo: meta-isar-yogurt
         path: 0001-rootfs-Use-separate-mounts-lock-file.patch
       0002-rootfs-refs:
-        repo: meta-isar-qtdemo
+        repo: meta-isar-yogurt
         path: 0002-image-Add-reference-counter.patch
       0003-ubifs-cross-compile:
-        repo: meta-isar-qtdemo
+        repo: meta-isar-yogurt
         path: 0003-ubifs-img-Force-cross-compile-usage.patch
       0004-buildchroot-deps-var:
-        repo: meta-isar-qtdemo
+        repo: meta-isar-yogurt
         path: 0004-buildchroot-Introduce-buildchroot-dependency-variabl.patch
       0005-buildchroot-deps-apt:
-        repo: meta-isar-qtdemo
+        repo: meta-isar-yogurt
         path: 0005-buildchroot-Move-apt_fetch-dependency-to-dpkg-base.patch
       0006-buildchroot-deps-imager:
-        repo: meta-isar-qtdemo
+        repo: meta-isar-yogurt
         path: 0006-image-Fix-do_install_imager_deps-dependency.patch
       0007-ubifs-chown:
-        repo: meta-isar-qtdemo
+        repo: meta-isar-yogurt
         path: 0007-ubifs-Fix-output-files-permissions.patch
   meta-isar-phytec:
-    url: "https://github.com/phytec/meta-isar-phytec"
-    refspec: "ada71b3877c63a1ae7097d2b19290991d34afdbc"
-  meta-isar-qtdemo:
-    url: "https://github.com/phytec/meta-isar-qtdemo"
-    refspec: "ef465859d6ab45950e5d54529b18711720e3e572"
+    url: "git@github.com:/ilbers/meta-isar-phytec"
+    refspec: "9cf474de9b159aef1653bf1346109920a92ec0d1"
+  meta-isar-yogurt:
+    url: "git@github.com:/ilbers/meta-isar-yogurt"
+    refspec: "522f4d5650e29bc02857bf84033a0fbc58f042b2"
 
 bblayers_conf_header:
   standard: |

--- a/kas_yogurt.yml
+++ b/kas_yogurt.yml
@@ -11,30 +11,30 @@ repos:
       meta-isar:
     patches:
       0001-separate-locks:
-        repo: meta-isar-yogurt
+        repo: meta-isar-qtdemo
         path: 0001-rootfs-Use-separate-mounts-lock-file.patch
       0002-rootfs-refs:
-        repo: meta-isar-yogurt
+        repo: meta-isar-qtdemo
         path: 0002-image-Add-reference-counter.patch
       0003-ubifs-cross-compile:
-        repo: meta-isar-yogurt
+        repo: meta-isar-qtdemo
         path: 0003-ubifs-img-Force-cross-compile-usage.patch
       0004-buildchroot-deps-var:
-        repo: meta-isar-yogurt
+        repo: meta-isar-qtdemo
         path: 0004-buildchroot-Introduce-buildchroot-dependency-variabl.patch
       0005-buildchroot-deps-apt:
-        repo: meta-isar-yogurt
+        repo: meta-isar-qtdemo
         path: 0005-buildchroot-Move-apt_fetch-dependency-to-dpkg-base.patch
       0006-buildchroot-deps-imager:
-        repo: meta-isar-yogurt
+        repo: meta-isar-qtdemo
         path: 0006-image-Fix-do_install_imager_deps-dependency.patch
       0007-ubifs-chown:
-        repo: meta-isar-yogurt
+        repo: meta-isar-qtdemo
         path: 0007-ubifs-Fix-output-files-permissions.patch
   meta-isar-phytec:
     url: "git@github.com:/ilbers/meta-isar-phytec"
     refspec: "9cf474de9b159aef1653bf1346109920a92ec0d1"
-  meta-isar-yogurt:
+  meta-isar-qtdemo:
     url: "git@github.com:/ilbers/meta-isar-yogurt"
     refspec: "522f4d5650e29bc02857bf84033a0fbc58f042b2"
 

--- a/kas_yogurt.yml
+++ b/kas_yogurt.yml
@@ -4,7 +4,7 @@ header:
 build_system: isar
 repos:
   isar:
-    url: "git@github.com:/ilbers/isar"
+    url: "https://github.com/ilbers/isar"
     refspec: "1fd9f5de842ba1ed4ccbb555527f25bc839a6a6b"
     layers:
       meta:
@@ -32,11 +32,11 @@ repos:
         repo: meta-isar-qtdemo
         path: 0007-ubifs-Fix-output-files-permissions.patch
   meta-isar-phytec:
-    url: "git@github.com:/ilbers/meta-isar-phytec"
-    refspec: "9cf474de9b159aef1653bf1346109920a92ec0d1"
+    url: "https://github.com/phytec/meta-isar-phytec"
+    refspec: "ada71b3877c63a1ae7097d2b19290991d34afdbc"
   meta-isar-qtdemo:
-    url: "git@github.com:/ilbers/meta-isar-yogurt"
-    refspec: "522f4d5650e29bc02857bf84033a0fbc58f042b2"
+    url: "https://github.com/phytec/meta-isar-qtdemo"
+    refspec: "ef465859d6ab45950e5d54529b18711720e3e572"
 
 bblayers_conf_header:
   standard: |

--- a/kas_yogurt.yml
+++ b/kas_yogurt.yml
@@ -4,39 +4,39 @@ header:
 build_system: isar
 repos:
   isar:
-    url: "git@github.com:/ilbers/isar"
+    url: "https://github.com/ilbers/isar"
     refspec: "1fd9f5de842ba1ed4ccbb555527f25bc839a6a6b"
     layers:
       meta:
       meta-isar:
     patches:
       0001-separate-locks:
-        repo: meta-isar-yogurt
+        repo: meta-isar-qtdemo
         path: 0001-rootfs-Use-separate-mounts-lock-file.patch
       0002-rootfs-refs:
-        repo: meta-isar-yogurt
+        repo: meta-isar-qtdemo
         path: 0002-image-Add-reference-counter.patch
       0003-ubifs-cross-compile:
-        repo: meta-isar-yogurt
+        repo: meta-isar-qtdemo
         path: 0003-ubifs-img-Force-cross-compile-usage.patch
       0004-buildchroot-deps-var:
-        repo: meta-isar-yogurt
+        repo: meta-isar-qtdemo
         path: 0004-buildchroot-Introduce-buildchroot-dependency-variabl.patch
       0005-buildchroot-deps-apt:
-        repo: meta-isar-yogurt
+        repo: meta-isar-qtdemo
         path: 0005-buildchroot-Move-apt_fetch-dependency-to-dpkg-base.patch
       0006-buildchroot-deps-imager:
-        repo: meta-isar-yogurt
+        repo: meta-isar-qtdemo
         path: 0006-image-Fix-do_install_imager_deps-dependency.patch
       0007-ubifs-chown:
-        repo: meta-isar-yogurt
+        repo: meta-isar-qtdemo
         path: 0007-ubifs-Fix-output-files-permissions.patch
   meta-isar-phytec:
-    url: "git@github.com:/ilbers/meta-isar-phytec"
-    refspec: "9cf474de9b159aef1653bf1346109920a92ec0d1"
-  meta-isar-yogurt:
-    url: "git@github.com:/ilbers/meta-isar-yogurt"
-    refspec: "522f4d5650e29bc02857bf84033a0fbc58f042b2"
+    url: "https://github.com/phytec/meta-isar-phytec"
+    refspec: "ada71b3877c63a1ae7097d2b19290991d34afdbc"
+  meta-isar-qtdemo:
+    url: "https://github.com/phytec/meta-isar-qtdemo"
+    refspec: "ef465859d6ab45950e5d54529b18711720e3e572"
 
 bblayers_conf_header:
   standard: |


### PR DESCRIPTION
renaming of layer meta-isar-yogurt to meta-isar-qtdemo
url changes (git@github.com:/ -> https://github.com/) otherwise no access possible
url changes (now phytec repos available)